### PR TITLE
Fixed plot label issue

### DIFF
--- a/camoco/COB.py
+++ b/camoco/COB.py
@@ -778,7 +778,7 @@ class COB(Expr):
                     xticks=np.arange(len(dm.columns)),
                     xticklabels=dm.columns.values
                 )
-                ax.set_xticklabels(ax.xaxis.get_majorticklabels(), rotation=90)
+                ax.set_xticklabels(dm.columns, rotation=90)
         if (include_gene_labels is None and len(dm.index) < 100) \
             or include_gene_labels == True:
                 ax.set(


### PR DESCRIPTION
x-axis labels would not print properly when running cob.plot()

![testing](https://cloud.githubusercontent.com/assets/14349312/16395820/5de4c606-3c81-11e6-8fb8-5eb720e48d93.png)
![soygenotest_expr_norm](https://cloud.githubusercontent.com/assets/14349312/16395826/6a93a1ec-3c81-11e6-9cdf-81cf079fd00d.png)
