### PR TITLE
Integrate Coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install pytest-cov
+  - conda install coveralls
+
 # command to run tests, e.g. python setup.py test
-script:  
+script:
   - source $HOME/.camoco/conda/bin/activate camoco
   - export PATH=/home/travis/.camoco/bin/:$PATH
   - which py.test
@@ -24,4 +26,3 @@ script:
 
 after_success:
   - coveralls
- 


### PR DESCRIPTION
This should be the only change required in the build config in order to publish the coverage report to Coveralls.io. Other than this you should just go to coveralls.io and enable code coverage for this repo.

Tried to test it, but Travis-CI builds were failing for me, so I added an `after_failure` step with coveralls publishing just to see if the API works, and it seems to be ok (see [here](https://coveralls.io/github/fuzzmz/Camoco)).

I say seems to be ok because it gives 0% coverage, but I'm not sure that's because of the failing tests or not. Any idea on this, or on how to better test it?

Fixes #72 