### PR TITLE
Specified Networkx Version, Fixed Parallel Bug

### DIFF
--- a/camoco/Camoco.py
+++ b/camoco/Camoco.py
@@ -143,7 +143,7 @@ class Camoco(object):
         )
 
     def _global(self, key, val=None):
-        # set the global for the dataset
+        # Set the global for the dataset
         try:
             if val is not None:
                 self.db.cursor().execute('''

--- a/camoco/GWAS.py
+++ b/camoco/GWAS.py
@@ -95,18 +95,6 @@ class GWAS(Ontology):
             DELETE FROM loci_attr WHERE term = ?
         ''',(id,))
 
-    def set_strongest(self,attr=None,higher=None):
-        if not(attr is None):
-            self._global('strongest_attr',attr)
-        if not(higher is None):
-            self._global('strongest_higher',higher)
-    
-    def get_strongest_attr(self):
-        return self._global('strongest_attr')
-    
-    def get_strongest_higher(self):
-        return self._global('strongest_higher')
-        
 
     ''' -----------------------------------------------------------------------
             Internal Methods -- Factory Methods

--- a/camoco/Ontology.py
+++ b/camoco/Ontology.py
@@ -303,6 +303,42 @@ class Ontology(Camoco):
             self.del_term(term, cursor=cur)
         cur.execute('END TRANSACTION')
 
+    def set_strongest(self,attr=None,higher=None):
+        '''
+            Convinience function that allows you to set default values for
+            strongest SNP2Gene mapping tasks.
+
+            Parameters
+            ----------
+            attr:     The locus attr used to determine which locus is the 
+                      strongest locus.
+            
+            higher:   Flag indicating whether the value in --strongest-attr
+                      is stronger if it is higher. Default behavior is to
+                      treatlower values as stronger (i.e. p-vals)
+        '''
+        if not(attr is None):
+            self._global('strongest_attr',attr)
+        if not(higher is None):
+            self._global('strongest_higher',higher)
+
+    def get_strongest_attr(self):
+        '''
+            Convinience function that allows you to get the default value for
+            the locus attr used to determine which locus is the strongest locus
+            strongest SNP2Gene mapping.
+        '''
+        return self._global('strongest_attr')
+    
+    def get_strongest_higher(self):
+        '''
+            Convinience function that allows you to get default values for
+            the flag indicating whether the value in `strongest-attr` is
+            is stronger if higher for strongest SNP2Gene mapping tasks.
+        '''
+        return self._global('strongest_higher')
+
+
     @classmethod
     def create(cls, name, description, refgen, type='Ontology'):
         '''

--- a/camoco/Overlap.py
+++ b/camoco/Overlap.py
@@ -606,9 +606,9 @@ class Overlap(Camoco):
         # Save strongest description arguments if applicable
         if 'strongest' in self.args.snp2gene:
             if not(self.ont._global('strongest_attr') == args.strongest_attr):
-                self.ont._global('strongest_attr', args.strongest_attr)
+                self.ont.set_strongest(attr=args.strongest_attr)
             if not(bool(int(self.ont._global('strongest_higher'))) == bool(args.strongest_higher)):
-                self.ont._global('strongest_higher', args.strongest_higher)
+                self.ont.set_strongest(higher=args.strongest_higher)
         
         # Generate a terms iterable
         if 'all' in self.args.terms:

--- a/camoco/Overlap.py
+++ b/camoco/Overlap.py
@@ -158,14 +158,10 @@ class Overlap(Camoco):
                 window_size=self.args.candidate_window_size
             )
         elif 'strongest' in self.args.snp2gene:
-            if not(self.args.strongest_attr == 'pval'):
-                ont.set_strongest(attr=self.args.strongest_attr)
-            if not(self.args.strongest_higher == True):
-                ont.set_strongest(higher=self.args.strongest_higher)
             return term.strongest_loci(
                 window_size=self.args.candidate_window_size,
-                attr=ont.get_strongest_attr(),
-                lowest=ont.get_strongest_higher()
+                attr=self.args.strongest_attr,
+                lowest=self.args.strongest_higher
             )
 
     def generate_bootstraps(self,loci,overlap):
@@ -606,15 +602,22 @@ class Overlap(Camoco):
         else:
             self.ont = co.GWAS(args.gwas)
         self.generate_output_name()
-
+        
+        # Save strongest description arguments if applicable
+        if 'strongest' in self.args.snp2gene:
+            if not(self.ont._global('strongest_attr') == args.strongest_attr):
+                self.ont._global('strongest_attr', args.strongest_attr)
+            if not(bool(int(self.ont._global('strongest_higher'))) == bool(args.strongest_higher)):
+                self.ont._global('strongest_higher', args.strongest_higher)
+        
         # Generate a terms iterable
         if 'all' in self.args.terms:
             terms = self.ont.iter_terms()
         else:
             terms = [self.ont[term] for term in self.args.terms]
         all_results = list()
-
         results = []
+        
         # Iterate through terms and calculate
         for term in terms:
             if term.id in self.args.skip_terms:
@@ -627,6 +630,7 @@ class Overlap(Camoco):
             if args.max_term_size != None and len(loci) > args.max_term_size:
                 self.cob.log('Too many genes to perform overlap')
                 continue
+            
             # Send some output to the terminal
             self.cob.log(
                 "Calculating Overlap for {} of {} in {} with window:{} and flank:{} ({} Loci)",

--- a/install.sh
+++ b/install.sh
@@ -194,7 +194,7 @@ then
     conda config --append channels blaze
     conda create -y -n $NAME python=3 setuptools pip cython numpy scipy pandas \
         matplotlib blaze nose six pyyaml yaml pyparsing python-dateutil \
-        pytz numexpr patsy statsmodels networkx mpmath termcolor scikit-learn \
+        pytz numexpr patsy statsmodels networkx=1.11 mpmath termcolor scikit-learn \
         ipython ipdb pytest-cov flask gunicorn apsw
 else
     green 'conda already installed'


### PR DESCRIPTION
When networkx upgraded to 2.0, it broke something in odo, but their conda recipe has not been updated to reflect this change or their software has not been properly fixed. They are aware of this problem: https://github.com/blaze/odo/issues/579 . 

Though we may want to consider assessing alternatives to Blaze and Odo given that Anaconda seems to be less invested in them lately, but I have not seen any official announcement to this effect, and the Repos seem to have awaken over the last couple of days. So who knows. This takes care ofthe problem for the time being.